### PR TITLE
Switch to JSON-only data management

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,17 @@ pip install -e .
 ```
 
 This will make the `basic_gym_env` package available in your Python environment.
+
+## JSON data files
+
+`BasicEnv` uses JSON files for all persistent data. The plants and regimens are
+stored in a shared file while every robot keeps its own list of pending tasks.
+
+```python
+from basic_gym_env.basic_env import BasicEnv
+
+env = BasicEnv(archivo_json='plantas.json', archivo_tareas='tareas_robot.json')
+```
+
+This setup lets multiple robots work in the same environment with the same
+plant configuration while maintaining independent task queues.

--- a/basic_gym_env/__init__.py
+++ b/basic_gym_env/__init__.py
@@ -1,9 +1,8 @@
 from .basic_env import BasicEnv
-from .plantas import PlantasManager
-from .regimenes import RegimenesManager
-from .ensayos import EnsayosEnv
+from nuevo_plantas import PlantasManager
+from .tasks_manager import RobotTasksManager
 from .interfaz import Interfaz
-#from .utils import crear_archivos_plantas_y_regimenes
+
 
 def register_env():
     from gym.envs.registration import register
@@ -11,5 +10,4 @@ def register_env():
         id='BasicEnv-v0',
         entry_point='basic_gym_env:BasicEnv',
     )
-
 register_env()

--- a/basic_gym_env/basic_env.py
+++ b/basic_gym_env/basic_env.py
@@ -1,9 +1,6 @@
 import matplotlib.pyplot as plt
-from openpyxl import load_workbook
-from .plantas import PlantasManager
-from .regimenes import RegimenesManager
-from .ensayos import EnsayosEnv
-#from .utils import crear_archivos_plantas_y_regimenes
+from nuevo_plantas import PlantasManager
+from .tasks_manager import RobotTasksManager
 import pygame
 import numpy as np
 import gym
@@ -12,23 +9,18 @@ import threading
 import time
 import queue
 import csv
-import matplotlib.pyplot as plt
-from openpyxl import load_workbook
-import pygame
 
 class BasicEnv(gym.Env):
     metadata = {'render.modes': ['human']}
 
     def __init__(self, port='COM6', baudrate=115200,
-                 archivo_plantas='archivo_plantas.xlsx',
-                 archivo_regimenes='archivo_regimenes.xlsx',
-                 archivo_ensayos='archivo_ensayos.xlsx'):
+                 archivo_json='plantas.json',
+                 archivo_tareas='tareas_robot.json'):
         super(BasicEnv, self).__init__()
 
-        # Inicializar gestores de plantas y regímenes
-        self.plantas_manager = PlantasManager(archivo_plantas)
-        self.regimenes_manager = RegimenesManager(archivo_regimenes)
-        self.ensayos_env = EnsayosEnv(archivo_plantas, archivo_regimenes, archivo_ensayos)
+        # Gestores de datos basados en JSON
+        self.plantas_manager = PlantasManager(archivo_json)
+        self.tareas_manager = RobotTasksManager(archivo_tareas)
 
         # Definir espacios de acción y observación
         self.action_space = gym.spaces.Box(
@@ -541,14 +533,22 @@ class BasicEnv(gym.Env):
     def eliminar_planta(self, era, fila):
         self.plantas_manager.eliminar_planta(era, fila)
 
-    def agregar_regimen(self, regimen_name):
-        self.regimenes_manager.agregar_regimen(regimen_name)
+    def agregar_regimen(self, *args, **kwargs):
+        return self.plantas_manager.crear_regimen(*args, **kwargs)
 
-    def modificar_tarea(self, regimen, fila, updated_values):
-        self.regimenes_manager.modificar_tarea(regimen, fila, updated_values)
+    def modificar_tarea(self, *args, **kwargs):
+        return self.plantas_manager.modificar_regimen(*args, **kwargs)
 
-    def eliminar_tarea(self, regimen, fila):
-        self.regimenes_manager.eliminar_tarea(regimen, fila)
+    def eliminar_tarea(self, *args, **kwargs):
+        return self.plantas_manager.eliminar_regimen(*args, **kwargs)
 
-    def crear_ensayo(self):
-        self.ensayos_env.crear_ensayo()
+    # Gestión de tareas específicas del robot
+    def agregar_tarea_robot(self, tarea):
+        self.tareas_manager.agregar_tarea(tarea)
+
+    def obtener_tareas_robot(self):
+        return self.tareas_manager.obtener_tareas()
+
+    def eliminar_tarea_robot(self, index):
+        self.tareas_manager.eliminar_tarea(index)
+

--- a/basic_gym_env/tasks_manager.py
+++ b/basic_gym_env/tasks_manager.py
@@ -1,0 +1,35 @@
+import json
+from typing import List, Dict, Any
+
+class RobotTasksManager:
+    """Manage per-robot task lists stored in a JSON file."""
+
+    def __init__(self, tasks_file: str = 'tareas_robot.json') -> None:
+        self.tasks_file = tasks_file
+        self.tareas: List[Dict[str, Any]] = []
+        self._load()
+
+    def _load(self) -> None:
+        try:
+            with open(self.tasks_file, 'r') as f:
+                data = json.load(f)
+                self.tareas = data.get('tareas', [])
+        except FileNotFoundError:
+            self.tareas = []
+
+    def _save(self) -> None:
+        with open(self.tasks_file, 'w') as f:
+            json.dump({'tareas': self.tareas}, f, indent=4)
+
+    def agregar_tarea(self, tarea: Dict[str, Any]) -> None:
+        """Add a new task dictionary to the list."""
+        self.tareas.append(tarea)
+        self._save()
+
+    def obtener_tareas(self) -> List[Dict[str, Any]]:
+        return list(self.tareas)
+
+    def eliminar_tarea(self, index: int) -> None:
+        if 0 <= index < len(self.tareas):
+            del self.tareas[index]
+            self._save()


### PR DESCRIPTION
## Summary
- drop Excel managers and rely entirely on JSON files
- introduce `RobotTasksManager` for per-robot task lists
- update `BasicEnv` to use the JSON managers
- document the new JSON usage pattern

## Testing
- `python -m py_compile basic_gym_env/basic_env.py basic_gym_env/tasks_manager.py nuevo_plantas.py`
- `python - <<'PY'
from basic_gym_env.basic_env import BasicEnv
try:
    BasicEnv()
except Exception as e:
    print(e)
PY`

------
https://chatgpt.com/codex/tasks/task_e_686ca85c57388330bfa66bcd96b6736f