### PR TITLE
Add serial port controls to Flask UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, request, jsonify
+from flask import Flask, render_template, request, jsonify, redirect, url_for
 import threading
 import time
 from basic_gym_env.basic_env import BasicEnv  # Asegúrate de que basic_env.py está en el mismo directorio
@@ -78,8 +78,12 @@ def robot_control():
             obs_dict = dict(zip(env.variable_names, obs_list))
         else:
             obs_dict = {}
+        serial_connected = env.ser is not None and env.ser.is_open
 
-    return render_template('robot_control.html', obs=obs_dict)
+    return render_template('robot_control.html',
+                           obs=obs_dict,
+                           current_port=env.port,
+                           serial_connected=serial_connected)
 @app.route('/get_observation')
 def get_observation():
     with env_lock:
@@ -101,5 +105,22 @@ def simulate_key():
         return jsonify({'status': 'Key processed'}), 200
     else:
         return jsonify({'error': 'No key provided'}), 400
+
+@app.route('/update_port', methods=['POST'])
+def update_port():
+    new_port = request.form.get('serial_port')
+    if new_port:
+        with env_lock:
+            env.change_port(new_port)
+    return redirect(url_for('robot_control'))
+
+@app.route('/toggle_connection', methods=['POST'])
+def toggle_connection():
+    with env_lock:
+        if env.ser is None or not env.ser.is_open:
+            env.connect_serial()
+        else:
+            env.disconnect_serial()
+    return redirect(url_for('robot_control'))
 if __name__ == '__main__':
     app.run(debug=True)

--- a/basic_gym_env/basic_env.py
+++ b/basic_gym_env/basic_env.py
@@ -180,6 +180,19 @@ class BasicEnv(gym.Env):
             self.ser = None
             return False
 
+    def disconnect_serial(self):
+        """Cerrar la conexión serial actual si está abierta."""
+        if self.ser is not None and self.ser.is_open:
+            self.ser.close()
+            print("Desconectado del puerto serial")
+
+    def change_port(self, new_port):
+        """Cambiar de puerto y reconectar."""
+        self.port = new_port
+        if self.mode == 'serial':
+            self.disconnect_serial()
+            self.connect_serial()
+
     def read_serial(self):
         if self.mode != 'serial':
             return

--- a/templates/robot_control.html
+++ b/templates/robot_control.html
@@ -5,6 +5,20 @@
 {% block content %}
 <h1>Control del Robot</h1>
 
+<form method="post" action="{{ url_for('update_port') }}" class="form-inline mb-3">
+    <div class="form-group mr-2">
+        <label for="serial_port" class="mr-2">Puerto COM</label>
+        <input type="text" class="form-control" id="serial_port" name="serial_port" value="{{ current_port }}">
+    </div>
+    <button type="submit" class="btn btn-warning">Cambiar Puerto</button>
+</form>
+
+<form method="post" action="{{ url_for('toggle_connection') }}" class="mb-4">
+    <button type="submit" class="btn btn-secondary">
+        {% if serial_connected %}Desconectar{% else %}Conectar{% endif %}
+    </button>
+</form>
+
 <form method="post">
     <div class="form-group form-check">
         <input type="checkbox" class="form-check-input" id="manual_mode" name="manual_mode" {% if obs.get('modoManual') == 1 %}checked{% endif %}>


### PR DESCRIPTION
## Summary
- add disconnect/change_port methods to `BasicEnv`
- enable changing the serial port from the Flask interface
- add connect/disconnect buttons

## Testing
- `python -m py_compile app.py basic_gym_env/basic_env.py`
- `pip install -q -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6874624aea1083309cce4ccc9129cf5c