### PR TITLE
Fix server blocking on missing serial data

### DIFF
--- a/basic_gym_env/basic_env.py
+++ b/basic_gym_env/basic_env.py
@@ -409,11 +409,15 @@ class BasicEnv(gym.Env):
                 self.ser = None
 
             obs = self.get_observation()
-            while obs is None:
+            waited = 0
+            while obs is None and waited < 3:
                 try:
                     obs = self.data_queue.get(timeout=1)
                 except queue.Empty:
-                    continue
+                    waited += 1
+            if obs is None:
+                # En ausencia de datos del robot, devuelve una observación por defecto
+                obs = np.zeros(self.observation_space.shape, dtype=np.float32)
         else:
             angle_rad = np.deg2rad(self.current_action[5])
             slide_pos = -(self.current_action[4] / 1000.0) * 0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,7 @@ pyserial
 pybullet
 pygame
 simple-pid
+Flask
+pandas
+matplotlib
+openpyxl


### PR DESCRIPTION
## Summary
- prevent BasicEnv.step from blocking forever when no serial data is present
- require Flask, pandas, matplotlib and openpyxl

## Testing
- `python -m py_compile servidor_plantas.py basic_gym_env/basic_env.py`

------
https://chatgpt.com/codex/tasks/task_e_68746b3ab3608330ac5ad70ccd1ba399