### PR TITLE
Add COM port selector to panel interface

### DIFF
--- a/servidor_plantas.py
+++ b/servidor_plantas.py
@@ -384,8 +384,12 @@ def robot_control():
             obs_dict = dict(zip(servidor.env.variable_names, obs_list))
         else:
             obs_dict = {}
+        serial_connected = servidor.env.ser is not None and servidor.env.ser.is_open
 
-    return render_template('simple_panel.html', obs=obs_dict)
+    return render_template('panel.html',
+                           obs=obs_dict,
+                           current_port=servidor.env.port,
+                           serial_connected=serial_connected)
 
 @app.route('/get_observation')
 def get_observation():
@@ -407,6 +411,23 @@ def simulate_key():
         return jsonify({'status': 'Key processed'}), 200
     else:
         return jsonify({'error': 'No key provided'}), 400
+
+@app.route('/update_port', methods=['POST'])
+def update_port():
+    new_port = request.form.get('serial_port')
+    if new_port:
+        with env_lock:
+            servidor.env.change_port(new_port)
+    return redirect(url_for('robot_control'))
+
+@app.route('/toggle_connection', methods=['POST'])
+def toggle_connection():
+    with env_lock:
+        if servidor.env.ser is None or not servidor.env.ser.is_open:
+            servidor.env.connect_serial()
+        else:
+            servidor.env.disconnect_serial()
+    return redirect(url_for('robot_control'))
 
 # ---- Endpoints ----
 

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -142,7 +142,12 @@ body{background:#f8f9fa;}
       <label for="robot-select" class="mr-2">Robot:</label>
       <select id="robot-select" class="form-control form-control-sm"></select>
     </div>
-    <p id="mcu-ip" class="mb-0 text-muted small">IP: --</p>
+    <form method="post" action="{{ url_for('update_port') }}" class="form-inline ml-2">
+      <label for="serial_port" class="mr-2">Puerto COM:</label>
+      <input type="text" id="serial_port" name="serial_port" class="form-control form-control-sm mr-2" value="{{ current_port }}">
+      <button type="submit" class="btn btn-warning btn-sm">Cambiar</button>
+    </form>
+    <p id="mcu-ip" class="mb-0 text-muted small ml-2">IP: --</p>
     <p id="robot-type" class="mb-0 text-muted small ml-2">Tipo: --</p>
     <p id="robot-sensors" class="mb-0 text-muted small ml-2">Sensores: --</p>
     <p id="robot-motors" class="mb-0 text-muted small ml-2">Actuadores: --</p>


### PR DESCRIPTION
## Summary
- show COM port selection form in `panel.html`
- serve `panel.html` with current port information
- add `/update_port` and `/toggle_connection` routes to `servidor_plantas.py`

## Testing
- `python -m py_compile app.py servidor_plantas.py basic_gym_env/basic_env.py`

------
https://chatgpt.com/codex/tasks/task_e_6874790824c88330a68cc2aedc349b79