### PR TITLE
Improve serial port debug logging

### DIFF
--- a/basic_gym_env/basic_env.py
+++ b/basic_gym_env/basic_env.py
@@ -17,11 +17,12 @@ class BasicEnv(gym.Env):
     def __init__(self, port='COM6', baudrate=115200,
                  archivo_json='data/plants.json',
                  archivo_tareas='data/tasks.json',
-                 mode='serial', render=True):
+                 mode='serial', render=True, logger=None):
         super(BasicEnv, self).__init__()
 
         self.mode = mode
         self.render = render
+        self.logger = logger if logger is not None else print
 
         # Gestores de datos basados en JSON
         self.plantas_manager = PlantasManager(archivo_json)
@@ -182,14 +183,15 @@ class BasicEnv(gym.Env):
         self.last_serial_attempt = now
 
         try:
+            self.logger(f"Intentando conectar al puerto serial {self.port}")
             self.ser = serial.Serial(self.port, self.baudrate, timeout=0.3)
             time.sleep(2)
-            print("Conectado al puerto serial", self.port)
+            self.logger(f"Conectado al puerto serial {self.port}")
             self.serial_error_logged = False
             return True
         except serial.SerialException as e:
             if not self.serial_error_logged:
-                print(f"Error al conectar al puerto serial: {e}")
+                self.logger(f"Error al conectar al puerto serial: {e}")
                 self.serial_error_logged = True
             self.ser = None
             return False
@@ -198,11 +200,12 @@ class BasicEnv(gym.Env):
         """Cerrar la conexión serial actual si está abierta."""
         if self.ser is not None and self.ser.is_open:
             self.ser.close()
-            print("Desconectado del puerto serial")
+            self.logger("Desconectado del puerto serial")
         self.serial_error_logged = False
 
     def change_port(self, new_port):
         """Cambiar de puerto y reconectar."""
+        self.logger(f"Cambiando puerto serial a {new_port}")
         self.port = new_port
         if self.mode == 'serial':
             self.disconnect_serial()
@@ -230,17 +233,17 @@ class BasicEnv(gym.Env):
                         buffer = buffer[end + 1:]
                         self.process_serial_line(line)
             except serial.SerialException as e:
-                print(f"Serial read error: {e}")
+                self.logger(f"Serial read error: {e}")
                 self.ser = None
             except Exception as e:
-                print(f"Unexpected error: {e}")
+                self.logger(f"Unexpected error: {e}")
 
     def process_serial_line(self, line):
         # Dividir la línea por comas
         values = line.strip().split(',')
 
         if len(values) not in (21, 24):
-            print(f"Error: expected 21 or 24 values, got {len(values)}")
+            self.logger(f"Error: expected 21 or 24 values, got {len(values)}")
             return
 
         # Valores por defecto para el formato reducido

--- a/servidor_plantas.py
+++ b/servidor_plantas.py
@@ -52,7 +52,7 @@ def _save_json(path, data):
 class ServidorFlask:
     def __init__(self):
         # Inicializamos el entorno y el gestor de plantas
-        self.env = BasicEnv(port='COM5', baudrate=115200)
+        self.env = BasicEnv(port='COM5', baudrate=115200, logger=self.log)
         self.manager = PlantasManager()
         self.logs = []
 
@@ -445,16 +445,20 @@ def simulate_key():
 def update_port():
     new_port = request.form.get('serial_port')
     if new_port:
+        servidor.log(f"Solicitud para cambiar a puerto {new_port}")
         with env_lock:
             servidor.env.change_port(new_port)
+        servidor.log(f"Puerto actual: {servidor.env.port}")
     return redirect(url_for('robot_control'))
 
 @app.route('/toggle_connection', methods=['POST'])
 def toggle_connection():
     with env_lock:
         if servidor.env.ser is None or not servidor.env.ser.is_open:
+            servidor.log("Intentando conectar al puerto serial")
             servidor.env.connect_serial()
         else:
+            servidor.log("Desconectando del puerto serial")
             servidor.env.disconnect_serial()
     return redirect(url_for('robot_control'))
 


### PR DESCRIPTION
## Summary
- inject logger into `BasicEnv` so server can capture serial messages
- log serial connection events when updating the port or toggling connection

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688848abefe0833088b1788fabdcf5a6