### PR TITLE
Fix log init in ServidorFlask

### DIFF
--- a/servidor_plantas.py
+++ b/servidor_plantas.py
@@ -51,10 +51,14 @@ def _save_json(path, data):
 
 class ServidorFlask:
     def __init__(self):
+        # Inicializamos la lista de logs antes de crear el entorno ya que este
+        # podría llamar al logger durante su construcción.  Si ``self.logs`` no
+        # existiera en ese momento se produciría un ``AttributeError``.
+        self.logs = []
+
         # Inicializamos el entorno y el gestor de plantas
         self.env = BasicEnv(port='COM5', baudrate=115200, logger=self.log)
         self.manager = PlantasManager()
-        self.logs = []
 
     def log(self, message):
         timestamp = datetime.now().strftime("%H:%M:%S")


### PR DESCRIPTION
## Summary
- avoid AttributeError when BasicEnv logs during initialization by creating the log list first

## Testing
- `python -m py_compile servidor_plantas.py basic_gym_env/basic_env.py nuevo_plantas.py protocolos.py`

------
https://chatgpt.com/codex/tasks/task_e_68884dec75b08330a1b981b2443d03b0