### PR TITLE
Improve status endpoint

### DIFF
--- a/servidor_plantas.py
+++ b/servidor_plantas.py
@@ -722,8 +722,15 @@ def status():
     """Devuelve un resumen del estado actual del entorno."""
     obs = servidor.env.get_observation()
     if obs is None:
-        return jsonify({'error': 'No hay observación disponible'}), 500
-    obs_list = obs.tolist()
+        # Intentar generar una observación realizando un paso
+        try:
+            servidor.env.step()
+            obs = servidor.env.get_observation()
+        except Exception:
+            obs = None
+    if obs is None:
+        obs = [0.0] * len(servidor.env.variable_names)
+    obs_list = obs if isinstance(obs, list) else obs.tolist()
     obs_dict = dict(zip(servidor.env.variable_names, obs_list))
 
     data = {


### PR DESCRIPTION
## Summary
- ensure `/status` returns zeros when there is no observation
- attempt a simulation step when status data is missing

## Testing
- `pip install -r requirements.txt` *(fails: building wheel for pybullet cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6888539889dc8330b48420388dff4b79