### PR TITLE
Fix PID form reset and hide status display

### DIFF
--- a/static/js/panel.js
+++ b/static/js/panel.js
@@ -405,16 +405,10 @@ window.addEventListener('DOMContentLoaded', () => {
       ui.status.textContent = lines.join('\n');
 
       if(isBasicEnv){
-        qs('#pidc-kp').value = (+st.KpC).toFixed(2);
-        qs('#pidc-ki').value = (+st.KiC).toFixed(2);
-        qs('#pidc-kd').value = (+st.KdC).toFixed(2);
         qs('#pidc-kp-cur').textContent = (+st.KpC).toFixed(2);
         qs('#pidc-ki-cur').textContent = (+st.KiC).toFixed(2);
         qs('#pidc-kd-cur').textContent = (+st.KdC).toFixed(2);
 
-        qs('#pida-kp').value = (+st.KpA).toFixed(2);
-        qs('#pida-ki').value = (+st.KiA).toFixed(2);
-        qs('#pida-kd').value = (+st.KdA).toFixed(2);
         qs('#pida-kp-cur').textContent = (+st.KpA).toFixed(2);
         qs('#pida-ki-cur').textContent = (+st.KiA).toFixed(2);
         qs('#pida-kd-cur').textContent = (+st.KdA).toFixed(2);

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -156,7 +156,7 @@ body{background:#f8f9fa;}
   <!-- Estado + ejecución -->
   <div class="card mb-3">
     <div class="card-body d-flex flex-column flex-md-row justify-content-between align-items-center">
-      <pre id="status" class="mb-3 mb-md-0 text-monospace small">
+      <pre id="status" class="mb-3 mb-md-0 text-monospace small d-none">
 Flow -- ml/s — SP --
 Servo --°
 PID --, FF --


### PR DESCRIPTION
## Summary
- Hide dashboard status text to remove static flow/angle/PID readout.
- Prevent PID coefficient inputs from resetting by only updating the current value labels.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893ef230d1c833085ef2c0486cadfb4