### PR TITLE
Show regimen tasks and name on selection

### DIFF
--- a/static/js/panel.js
+++ b/static/js/panel.js
@@ -674,6 +674,11 @@ window.addEventListener('DOMContentLoaded', () => {
     tasks=await api('/api/tasks');
     /* régimen actual (tab reg) */
     const filt=currentRegId?tasks.filter(t=>t.reg==currentRegId):tasks;
+    const title=qs('#currentRegName');
+    if(title){
+      const reg=regs.find(r=>r.id==currentRegId);
+      title.textContent=reg?`Régimen: ${reg.n}`:'';
+    }
     buildCalendar('#calendar',filt,'#weekSlider','#weekLabel','#initialDate');
     enableTaskClicks(filt,'detail','#calendar',false); enableEmptyCellClicks('calendar','detail',filt,'#weekSlider','#initialDate');
     /* todas las tareas (dashboard) */
@@ -811,6 +816,10 @@ window.addEventListener('DOMContentLoaded', () => {
   qs('#rg-id') ?.addEventListener('input', updateRgBtn);
   qs('#pl-save')?.addEventListener('click', savePlant);
   qs('#pl-del') ?.addEventListener('click', delPlant);
+  qs('#pl-reg') ?.addEventListener('change', () => {
+    currentRegId = val('#pl-reg') ? parseInt(val('#pl-reg'),10) : null;
+    loadCalendarTasks();
+  });
   qs('#pl-copy-current')?.addEventListener('click', () => {
     const s1 = lastStatus?.s1 ?? lastStatus?.servo1 ??
                qs('#s1-slider')?.noUiSlider?.get();

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -553,6 +553,7 @@ K K D --
 
       <!-- calendario régimen -->
       <div id="calendar-container" class="mb-3">
+        <h6 id="currentRegName" class="text-center mb-2"></h6>
         <div id="calendar"></div>
       </div>
 


### PR DESCRIPTION
## Summary
- display selected regimen name above calendar
- reload regimen tasks when selecting a regimen for a plant

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893f2381b688330a5c00d97716f8ea0