### PR TITLE
refactor: relocate energy controls and sync charts with live values

### DIFF
--- a/static/js/panel.js
+++ b/static/js/panel.js
@@ -40,7 +40,6 @@ window.addEventListener('DOMContentLoaded', () => {
 
   /* ===== Referencias UI ====================================== */
   const ui = {
-    status : qs('#status'),
     logs   : qs('#logs'),
     badge  : qs('#execBadge'),
     btn    : qs('#execBtn'),
@@ -54,9 +53,11 @@ window.addEventListener('DOMContentLoaded', () => {
     ffCard : qs('#ff-card'),
     ffWrap : qs('#ff-switch-wrap'),
     manualBtn: qs('#manual-toggle'),
-    manualBadge: qs('#manual-badge'),
-    manualSliders: qs('#manual-sliders')
+    manualBadge: qs('#manual-badge')
   };
+  const energyWraps = qsa('.energy-wrap');
+  // show energy controls by default; disabled state is managed later
+  energyWraps.forEach(w=>w.style.display='');
   let autoExec=false, regs=[], plants=[], tasks=[], currentRegId=null,
       tick=0, editingTask=null, currentRobot=0,
       lastStatus=null, pidEditable=true, isBasicEnv=false,
@@ -383,26 +384,22 @@ window.addEventListener('DOMContentLoaded', () => {
       if(ui.manualBtn){
         ui.manualBtn.textContent = manualMode ? 'Desactivar modo manual':'Activar modo manual';
       }
-      if(ui.manualSliders){
-        ui.manualSliders.style.display = manualMode ? '' : 'none';
-      }
+      // ensure energy controls stay visible but toggle interactivity via disabled state
+      energyWraps.forEach(w=>w.style.display='');
+      const setDisabled = (sel,dis)=>{
+        const el = qs(sel); if(!el || !el.noUiSlider) return;
+        if(dis){ el.setAttribute('disabled',true); }
+        else { el.removeAttribute('disabled'); }
+      };
+      ['#s1-slider','#s2-slider','#servo-slider','#flow-slider'].forEach(sel=>setDisabled(sel,manualMode));
+      ['#energy-corredera-slider','#energy-angulo-slider','#energy-valvula-slider']
+        .forEach(sel=>setDisabled(sel,!manualMode));
       pidSw.checked = !!st.pidOn;
       if(pidBadge){
         pidBadge.textContent = st.pidOn ? 'ON':'OFF';
         pidBadge.className = `badge badge-${st.pidOn?'success':'secondary'} ml-1`;
       }
       pidCtrls.style.display = pidSw.checked ? '' : 'none';
-      const lines = [
-        `Flow ${( +st.flow ).toFixed(1)} ml/s — SP ${( +st.setpoint ).toFixed(1)}`,
-        `Ángulo ${ st.servo ?? '--'}°`
-      ];
-      if(pidEditable && 'Kp' in st){
-        lines.push(`PID ${ st.pidOn ? 'ON':'OFF'}, FF ${ st.ffOn ? 'ON':'OFF'}`);
-        lines.push(`K K D ${( +st.Kp ).toFixed(1)} ${( +st.Ki ).toFixed(1)} ${( +st.Kd ).toFixed(1)}`);
-      }else{
-        lines.push('PID N/A');
-      }
-      ui.status.textContent = lines.join('\n');
 
       if(isBasicEnv){
         qs('#pidc-kp-cur').textContent = (+st.KpC).toFixed(2);
@@ -422,6 +419,27 @@ window.addEventListener('DOMContentLoaded', () => {
       qs('#s1-real').textContent    = `${(+st.s1).toFixed(0)}°`;
       qs('#s2-real').textContent    = `${(+st.s2).toFixed(0)}°`;
       qs('#flow-real').textContent  = `${(+st.flow).toFixed(1)} ml/s`;
+
+      // sync sliders with real readings so UI and charts share the same source
+      qs('#s1-slider')?.noUiSlider?.set(+st.s1);
+      qs('#s2-slider')?.noUiSlider?.set(+st.s2);
+      qs('#servo-slider')?.noUiSlider?.set(+st.servo);
+      qs('#flow-slider')?.noUiSlider?.set(+st.setpoint);
+
+      if(manualMode){
+        // manual mode disables energy outputs
+        qs('#energy-corredera-slider')?.noUiSlider?.set(0);
+        qs('#energy-angulo-slider')?.noUiSlider?.set(0);
+        qs('#energy-valvula-slider')?.noUiSlider?.set(0);
+      }else{
+        // reflect controller energy when not in manual mode
+        qs('#energy-corredera-slider')?.noUiSlider?.set(st.energyCorredera ?? 0);
+        qs('#energy-angulo-slider')?.noUiSlider?.set(st.energyAngulo ?? 0);
+        qs('#energy-valvula-slider')?.noUiSlider?.set(st.energyValvula ?? 0);
+        // keep chart targets aligned with current positions
+        s1Target = +st.s1;
+        s2Target = +st.s2;
+      }
 
       autoExec=!!st.autoExecEnabled;
       ui.badge.textContent=autoExec?'⏳ En ejecución automática':'✔ Sistema en espera';

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -156,12 +156,6 @@ body{background:#f8f9fa;}
   <!-- Estado + ejecución -->
   <div class="card mb-3">
     <div class="card-body d-flex flex-column flex-md-row justify-content-between align-items-center">
-      <pre id="status" class="mb-3 mb-md-0 text-monospace small d-none">
-Flow -- ml/s — SP --
-Servo --°
-PID --, FF --
-K K D --
-      </pre>
       <div id="execBox" class="p-2 rounded bg-light text-center">
         <span id="execBadge" class="badge badge-success">✔ Sistema en espera</span>
         <button id="execBtn" class="btn btn-sm btn-primary ml-2">Activar ejecución</button>
@@ -186,14 +180,6 @@ K K D --
         <span id="manual-badge" class="badge badge-light">OFF</span>
       </h6>
       <button id="manual-toggle" class="btn btn-sm btn-secondary mb-2">Activar modo manual</button>
-      <div id="manual-sliders" style="display:none;">
-        <p class="small mb-1">Energía corredera <span id="energy-corredera-val" class="badge badge-info">0</span></p>
-        <div id="energy-corredera-slider"></div>
-        <p class="small mb-1 mt-2">Energía ángulo <span id="energy-angulo-val" class="badge badge-info">0</span></p>
-        <div id="energy-angulo-slider"></div>
-        <p class="small mb-1 mt-2">Energía válvula <span id="energy-valvula-val" class="badge badge-info">0</span></p>
-        <div id="energy-valvula-slider"></div>
-      </div>
     </div>
   </div>
 
@@ -203,9 +189,13 @@ K K D --
       <h6 class="card-title text-center mb-2">
         <span id="s1-name">Corredera</span>
         <span class="badge badge-light" id="s1-val">--°</span>
-        <span class="badge badge-info" id="s1-real">--°</span>
+        <span class="badge badge-success" id="s1-real">--°</span>
       </h6>
       <div id="s1-slider"></div>
+      <div id="energy-corredera-wrap" class="mt-2 energy-wrap" style="display:none;">
+        <p class="small mb-1">Energía corredera <span id="energy-corredera-val" class="badge badge-info">0</span></p>
+        <div id="energy-corredera-slider"></div>
+      </div>
       <div id="pid-s1" class="card mt-2" style="display:none;">
         <div class="card-header p-2">
           <a class="btn btn-link p-0" data-toggle="collapse" href="#pidS1Collapse">Config. PID ▼</a>
@@ -248,9 +238,13 @@ K K D --
       <h6 class="card-title text-center mb-2">
         <span id="s2-name">Ángulo</span>
         <span class="badge badge-light" id="s2-val">--°</span>
-        <span class="badge badge-info" id="s2-real">--°</span>
+        <span class="badge badge-success" id="s2-real">--°</span>
       </h6>
       <div id="s2-slider"></div>
+      <div id="energy-angulo-wrap" class="mt-2 energy-wrap" style="display:none;">
+        <p class="small mb-1">Energía ángulo <span id="energy-angulo-val" class="badge badge-info">0</span></p>
+        <div id="energy-angulo-slider"></div>
+      </div>
       <div id="pid-s2" class="card mt-2" style="display:none;">
         <div class="card-header p-2">
           <a class="btn btn-link p-0" data-toggle="collapse" href="#pidS2Collapse">Config. PID ▼</a>
@@ -296,14 +290,18 @@ K K D --
         <div class="col-6 col-md-4 mb-3">
           <h6>Servo válvula
             <span class="badge badge-light" id="servo-val">--°</span>
-            <span class="badge badge-info" id="servo-real">--°</span>
+            <span class="badge badge-success" id="servo-real">--°</span>
           </h6>
           <div id="servo-slider"></div>
+          <div id="energy-valvula-wrap" class="mt-2 energy-wrap" style="display:none;">
+            <p class="small mb-1">Energía válvula <span id="energy-valvula-val" class="badge badge-info">0</span></p>
+            <div id="energy-valvula-slider"></div>
+          </div>
         </div>
         <div class="col-6 col-md-4 mb-3">
           <h6>Flujo deseado
             <span class="badge badge-light" id="flow-val">-- ml/s</span>
-            <span class="badge badge-info" id="flow-real">-- ml/s</span>
+            <span class="badge badge-success" id="flow-real">-- ml/s</span>
           </h6>
           <div id="flow-slider"></div>
         </div>


### PR DESCRIPTION
## Summary
- remove status text block from dashboard
- show green live value badges and move each energy slider next to its actuator
- toggle actuator and energy sliders when switching manual mode
- keep energy sliders visible and sync actuator sliders & charts with live readings

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6893f4647ee883309eec3030f8e9a503