### PR TITLE
feat: add manual energy controls

### DIFF
--- a/static/js/panel.js
+++ b/static/js/panel.js
@@ -184,19 +184,20 @@ window.addEventListener('DOMContentLoaded', () => {
   mk('#flow-slider',0,30,0.1,0,'#flow-val',
      v=>api(`/control?flow=${v}`));
 
-  const mkEnergy = (sel,out,comp)=>{
+  const mkEnergy = (sel,out,btn,comp)=>{
     const el = qs(sel); if(!el) return;
     noUiSlider.create(el,{start:0,step:1,range:{min:-255,max:255}});
     el.noUiSlider.on('update',(_,__,v)=> qs(out).textContent=Math.round(v));
-    el.noUiSlider.on('change',(_,__,v)=>{
+    qs(btn)?.addEventListener('click',()=>{
+      const v = Math.round(el.noUiSlider.get());
       const d={manual_mode:1,motor_energies:{}};
-      d.motor_energies[comp]=Math.round(v);
+      d.motor_energies[comp]=v;
       apiJson('/entorno/actualizar_acciones',d).catch(console.warn);
     });
   };
-  mkEnergy('#energy-corredera-slider','#energy-corredera-val','corredera');
-  mkEnergy('#energy-angulo-slider','#energy-angulo-val','angulo');
-  mkEnergy('#energy-valvula-slider','#energy-valvula-val','valvula');
+  mkEnergy('#energy-corredera-slider','#energy-corredera-val','#energy-corredera-btn','corredera');
+  mkEnergy('#energy-angulo-slider','#energy-angulo-val','#energy-angulo-btn','angulo');
+  mkEnergy('#energy-valvula-slider','#energy-valvula-val','#energy-valvula-btn','valvula');
 
   /* mostrar gráficas al abrir config PID */
   const pidS1Col = $('#pidS1Collapse');
@@ -394,6 +395,8 @@ window.addEventListener('DOMContentLoaded', () => {
       ['#s1-slider','#s2-slider','#servo-slider','#flow-slider'].forEach(sel=>setDisabled(sel,manualMode));
       ['#energy-corredera-slider','#energy-angulo-slider','#energy-valvula-slider']
         .forEach(sel=>setDisabled(sel,!manualMode));
+      ['#energy-corredera-btn','#energy-angulo-btn','#energy-valvula-btn']
+        .forEach(sel=>{const b=qs(sel); if(b) b.disabled=!manualMode;});
       pidSw.checked = !!st.pidOn;
       if(pidBadge){
         pidBadge.textContent = st.pidOn ? 'ON':'OFF';
@@ -426,13 +429,7 @@ window.addEventListener('DOMContentLoaded', () => {
       qs('#servo-slider')?.noUiSlider?.set(+st.servo);
       qs('#flow-slider')?.noUiSlider?.set(+st.setpoint);
 
-      if(manualMode){
-        // manual mode disables energy outputs
-        qs('#energy-corredera-slider')?.noUiSlider?.set(0);
-        qs('#energy-angulo-slider')?.noUiSlider?.set(0);
-        qs('#energy-valvula-slider')?.noUiSlider?.set(0);
-      }else{
-        // reflect controller energy when not in manual mode
+      if(!manualMode){
         qs('#energy-corredera-slider')?.noUiSlider?.set(st.energyCorredera ?? 0);
         qs('#energy-angulo-slider')?.noUiSlider?.set(st.energyAngulo ?? 0);
         qs('#energy-valvula-slider')?.noUiSlider?.set(st.energyValvula ?? 0);

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -195,6 +195,7 @@ body{background:#f8f9fa;}
       <div id="energy-corredera-wrap" class="mt-2 energy-wrap" style="display:none;">
         <p class="small mb-1">Energía corredera <span id="energy-corredera-val" class="badge badge-info">0</span></p>
         <div id="energy-corredera-slider"></div>
+        <button id="energy-corredera-btn" class="btn btn-sm btn-primary mt-2">Manual</button>
       </div>
       <div id="pid-s1" class="card mt-2" style="display:none;">
         <div class="card-header p-2">
@@ -244,6 +245,7 @@ body{background:#f8f9fa;}
       <div id="energy-angulo-wrap" class="mt-2 energy-wrap" style="display:none;">
         <p class="small mb-1">Energía ángulo <span id="energy-angulo-val" class="badge badge-info">0</span></p>
         <div id="energy-angulo-slider"></div>
+        <button id="energy-angulo-btn" class="btn btn-sm btn-primary mt-2">Manual</button>
       </div>
       <div id="pid-s2" class="card mt-2" style="display:none;">
         <div class="card-header p-2">
@@ -296,6 +298,7 @@ body{background:#f8f9fa;}
           <div id="energy-valvula-wrap" class="mt-2 energy-wrap" style="display:none;">
             <p class="small mb-1">Energía válvula <span id="energy-valvula-val" class="badge badge-info">0</span></p>
             <div id="energy-valvula-slider"></div>
+            <button id="energy-valvula-btn" class="btn btn-sm btn-primary mt-2">Manual</button>
           </div>
         </div>
         <div class="col-6 col-md-4 mb-3">


### PR DESCRIPTION
## Summary
- add manual buttons for corredera, ángulo and válvula energy control
- send motor energy only on button press and keep slider values in manual mode

## Testing
- `node --check static/js/panel.js`
- `python -m py_compile servidor_plantas.py`


------
https://chatgpt.com/codex/tasks/task_e_6893fb0535648330a4387fe9439c6b31