### PR TITLE
Control manual por actuador sin botón global

### DIFF
--- a/static/js/panel.js
+++ b/static/js/panel.js
@@ -51,9 +51,7 @@ window.addEventListener('DOMContentLoaded', () => {
     motors : qs('#robot-motors'),
     cam    : qs('#cameraFeed'),
     ffCard : qs('#ff-card'),
-    ffWrap : qs('#ff-switch-wrap'),
-    manualBtn: qs('#manual-toggle'),
-    manualBadge: qs('#manual-badge')
+    ffWrap : qs('#ff-switch-wrap')
   };
   const energyWraps = qsa('.energy-wrap');
   // show energy controls by default; disabled state is managed later
@@ -61,7 +59,7 @@ window.addEventListener('DOMContentLoaded', () => {
   let autoExec=false, regs=[], plants=[], tasks=[], currentRegId=null,
       tick=0, editingTask=null, currentRobot=0,
       lastStatus=null, pidEditable=true, isBasicEnv=false,
-      s1Target=90, s2Target=90, manualMode=false;
+      s1Target=90, s2Target=90;
 
   const reloadCamera = () => {
     if(ui.cam) ui.cam.src = `/video_feed?ts=${Date.now()}`;
@@ -192,7 +190,12 @@ window.addEventListener('DOMContentLoaded', () => {
       const v = Math.round(el.noUiSlider.get());
       const d={manual_mode:1,motor_energies:{}};
       d.motor_energies[comp]=v;
-      apiJson('/entorno/actualizar_acciones',d).catch(console.warn);
+      apiJson('/entorno/actualizar_acciones',d)
+        .then(()=>apiJson('/entorno/actualizar_acciones',{
+          manual_mode:0,
+          motor_energies:{[comp]:0}
+        }))
+        .catch(console.warn);
     });
   };
   mkEnergy('#energy-corredera-slider','#energy-corredera-val','#energy-corredera-btn','corredera');
@@ -288,12 +291,6 @@ window.addEventListener('DOMContentLoaded', () => {
   ui.btn.onclick=()=>api(`/control?ejec=${autoExec?0:1}`)
                     .then(refreshStatus).catch(alert);
 
-  ui.manualBtn?.addEventListener('click',()=>{
-    const next = manualMode ? 0 : 1;
-    apiJson('/entorno/actualizar_acciones',{manual_mode:next})
-      .then(refreshStatus).catch(e=>alert(e.message));
-  });
-
   /* ===== Gráfica Flujo vs SP ================================ */
   const ctxFlow=qs('#chart').getContext('2d');
   const flowData={labels:[],datasets:[
@@ -378,25 +375,7 @@ window.addEventListener('DOMContentLoaded', () => {
     try{
       const st = await api('/status');
       lastStatus = st;
-      manualMode = !!st.manualMode;
-      if(ui.manualBadge){
-        ui.manualBadge.textContent = manualMode ? 'ON':'OFF';
-      }
-      if(ui.manualBtn){
-        ui.manualBtn.textContent = manualMode ? 'Desactivar modo manual':'Activar modo manual';
-      }
-      // ensure energy controls stay visible but toggle interactivity via disabled state
       energyWraps.forEach(w=>w.style.display='');
-      const setDisabled = (sel,dis)=>{
-        const el = qs(sel); if(!el || !el.noUiSlider) return;
-        if(dis){ el.setAttribute('disabled',true); }
-        else { el.removeAttribute('disabled'); }
-      };
-      ['#s1-slider','#s2-slider','#servo-slider','#flow-slider'].forEach(sel=>setDisabled(sel,manualMode));
-      ['#energy-corredera-slider','#energy-angulo-slider','#energy-valvula-slider']
-        .forEach(sel=>setDisabled(sel,!manualMode));
-      ['#energy-corredera-btn','#energy-angulo-btn','#energy-valvula-btn']
-        .forEach(sel=>{const b=qs(sel); if(b) b.disabled=!manualMode;});
       pidSw.checked = !!st.pidOn;
       if(pidBadge){
         pidBadge.textContent = st.pidOn ? 'ON':'OFF';
@@ -429,14 +408,12 @@ window.addEventListener('DOMContentLoaded', () => {
       qs('#servo-slider')?.noUiSlider?.set(+st.servo);
       qs('#flow-slider')?.noUiSlider?.set(+st.setpoint);
 
-      if(!manualMode){
-        qs('#energy-corredera-slider')?.noUiSlider?.set(st.energyCorredera ?? 0);
-        qs('#energy-angulo-slider')?.noUiSlider?.set(st.energyAngulo ?? 0);
-        qs('#energy-valvula-slider')?.noUiSlider?.set(st.energyValvula ?? 0);
-        // keep chart targets aligned with current positions
-        s1Target = +st.s1;
-        s2Target = +st.s2;
-      }
+      qs('#energy-corredera-slider')?.noUiSlider?.set(st.energyCorredera ?? 0);
+      qs('#energy-angulo-slider')?.noUiSlider?.set(st.energyAngulo ?? 0);
+      qs('#energy-valvula-slider')?.noUiSlider?.set(st.energyValvula ?? 0);
+      // keep chart targets aligned with current positions
+      s1Target = +st.s1;
+      s2Target = +st.s2;
 
       autoExec=!!st.autoExecEnabled;
       ui.badge.textContent=autoExec?'⏳ En ejecución automática':'✔ Sistema en espera';

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -173,16 +173,6 @@ body{background:#f8f9fa;}
     </div>
   </div>
 
-  <!-- Modo Manual -->
-  <div class="card mb-3">
-    <div class="card-body">
-      <h6 class="card-title mb-2">Modo manual
-        <span id="manual-badge" class="badge badge-light">OFF</span>
-      </h6>
-      <button id="manual-toggle" class="btn btn-sm btn-secondary mb-2">Activar modo manual</button>
-    </div>
-  </div>
-
   <!-- Corredera -->
   <div id="s1-card" class="card mb-3">
     <div class="card-body">
@@ -192,10 +182,10 @@ body{background:#f8f9fa;}
         <span class="badge badge-success" id="s1-real">--°</span>
       </h6>
       <div id="s1-slider"></div>
-      <div id="energy-corredera-wrap" class="mt-2 energy-wrap" style="display:none;">
+      <div id="energy-corredera-wrap" class="mt-2 energy-wrap">
         <p class="small mb-1">Energía corredera <span id="energy-corredera-val" class="badge badge-info">0</span></p>
         <div id="energy-corredera-slider"></div>
-        <button id="energy-corredera-btn" class="btn btn-sm btn-primary mt-2">Manual</button>
+        <button id="energy-corredera-btn" class="btn btn-sm btn-primary mt-2">Modo manual</button>
       </div>
       <div id="pid-s1" class="card mt-2" style="display:none;">
         <div class="card-header p-2">
@@ -242,10 +232,10 @@ body{background:#f8f9fa;}
         <span class="badge badge-success" id="s2-real">--°</span>
       </h6>
       <div id="s2-slider"></div>
-      <div id="energy-angulo-wrap" class="mt-2 energy-wrap" style="display:none;">
+      <div id="energy-angulo-wrap" class="mt-2 energy-wrap">
         <p class="small mb-1">Energía ángulo <span id="energy-angulo-val" class="badge badge-info">0</span></p>
         <div id="energy-angulo-slider"></div>
-        <button id="energy-angulo-btn" class="btn btn-sm btn-primary mt-2">Manual</button>
+        <button id="energy-angulo-btn" class="btn btn-sm btn-primary mt-2">Modo manual</button>
       </div>
       <div id="pid-s2" class="card mt-2" style="display:none;">
         <div class="card-header p-2">
@@ -295,10 +285,10 @@ body{background:#f8f9fa;}
             <span class="badge badge-success" id="servo-real">--°</span>
           </h6>
           <div id="servo-slider"></div>
-          <div id="energy-valvula-wrap" class="mt-2 energy-wrap" style="display:none;">
+          <div id="energy-valvula-wrap" class="mt-2 energy-wrap">
             <p class="small mb-1">Energía válvula <span id="energy-valvula-val" class="badge badge-info">0</span></p>
             <div id="energy-valvula-slider"></div>
-            <button id="energy-valvula-btn" class="btn btn-sm btn-primary mt-2">Manual</button>
+            <button id="energy-valvula-btn" class="btn btn-sm btn-primary mt-2">Modo manual</button>
           </div>
         </div>
         <div class="col-6 col-md-4 mb-3">


### PR DESCRIPTION
## Summary
- Remove global manual mode toggle from the control panel, leaving per-actuator manual buttons.
- Each actuator's manual button now sends energy commands and automatically resets the Arduino to a safe state.

## Testing
- `pytest`
- `python -m py_compile servidor_plantas.py`

------
https://chatgpt.com/codex/tasks/task_e_6894015d723c83308bbfe129befdda24