### PR TITLE
Add per-actuator manual toggles and sync Arduino positions

### DIFF
--- a/servidor_plantas.py
+++ b/servidor_plantas.py
@@ -84,6 +84,9 @@ class ServidorFlask:
         # Inicializamos el entorno y el gestor de plantas
         self.env = BasicEnv(port='COM5', baudrate=115200, logger=self.log)
         self.manager = PlantasManager()
+        self.manual_corredera = False
+        self.manual_angulo = False
+        self.manual_valvula = False
 
     def log(self, message):
         timestamp = datetime.now().strftime("%H:%M:%S")
@@ -99,12 +102,29 @@ class ServidorFlask:
             self.log("Ingresando a actualizar_acciones")
             self.log(f"Data recibida: {data}")
 
-            # Actualizar el modo manual si se proporciona
+            # Actualizar modos manuales individuales
+            flags_changed = False
+            for comp in ('corredera', 'angulo', 'valvula'):
+                key = f'manual_{comp}'
+                val = data.get(key)
+                if val is not None:
+                    setattr(self, key, bool(int(val)))
+                    self.log(f"{key} actualizado a {val}")
+                    flags_changed = True
+
             manual_mode = data.get('manual_mode')
-            if manual_mode is not None:
+            if flags_changed:
+                manual_mode = int(self.manual_corredera or self.manual_angulo or self.manual_valvula)
+                self.env.set_manual_mode(manual_mode)
+                self.log(f"manual_mode actualizado a {manual_mode}")
+            elif manual_mode is not None:
                 self.env.set_manual_mode(int(manual_mode))
                 self.log(f"manual_mode actualizado a {manual_mode}")
-
+                if int(manual_mode) == 0:
+                    self.manual_corredera = False
+                    self.manual_angulo = False
+                    self.manual_valvula = False
+            manual_mode = self.env.manual_mode
             # Configurar joypad si se proporciona
             joypad_action = data.get('joypad_action')
             if joypad_action:
@@ -759,12 +779,17 @@ def status():
     obs_dict = dict(zip(servidor.env.variable_names, obs_list))
 
     data = {
-        'flow': obs_dict.get('inputV', 0),
+        # Valores de sensores leídos directamente del Arduino
+        'flow': obs_dict.get('flowVolume', 0),
         'setpoint': servidor.env.current_action[6],
-        'servo': obs_dict.get('inputA', 0),
-        's1': obs_dict.get('inputX', 0),
-        's2': obs_dict.get('inputA', 0),
+        'servo': obs_dict.get('inputV', 0),
+        'x': obs_dict.get('inputX', 0),
+        'a': obs_dict.get('inputA', 0),
+        # Estados de modo manual por actuador
         'manualMode': servidor.env.manual_mode,
+        'manualCorredera': int(servidor.manual_corredera),
+        'manualAngulo': int(servidor.manual_angulo),
+        'manualValvula': int(servidor.manual_valvula),
         'pidOn': servidor.env.manual_mode == 0,
         'ffOn': False,
         'Kp': servidor.env.current_action[13],

--- a/static/js/panel.js
+++ b/static/js/panel.js
@@ -194,7 +194,7 @@ window.addEventListener('DOMContentLoaded', () => {
     el.noUiSlider.on('update',(_,__,v)=> qs(out).textContent=Math.round(v));
     el.noUiSlider.on('change',(_,__,v)=>{
       const val = Math.round(v);
-      const d={manual_mode:1,motor_energies:{}};
+      const d={motor_energies:{}};
       d.motor_energies[comp]=val;
       apiJson('/entorno/actualizar_acciones',d)
         .then(refreshStatus)
@@ -297,10 +297,11 @@ window.addEventListener('DOMContentLoaded', () => {
   Object.entries(manualToggles).forEach(([comp,btn])=>{
     if(!btn) return;
     btn.addEventListener('click',()=>{
-      manualState[comp] = !manualState[comp];
-      btn.textContent = manualState[comp] ? 'Desactivar modo manual' : 'Activar modo manual';
-      const manual_mode = Object.values(manualState).some(Boolean) ? 1 : 0;
-      apiJson('/entorno/actualizar_acciones',{manual_mode})
+      const cap = comp.charAt(0).toUpperCase()+comp.slice(1);
+      const current = lastStatus && lastStatus[`manual${cap}`];
+      const payload = {};
+      payload[`manual_${comp}`] = current ? 0 : 1;
+      apiJson('/entorno/actualizar_acciones',payload)
         .then(refreshStatus).catch(e=>alert(e.message));
     });
   });
@@ -461,15 +462,15 @@ window.addEventListener('DOMContentLoaded', () => {
       qs('#pid-kd-cur').textContent  = (+st.Kd).toFixed(1);
 
       qs('#servo-real').textContent = `${(+st.servo).toFixed(0)}°`;
-      qs('#s1-real').textContent    = `${(+st.s1).toFixed(0)}°`;
-      qs('#s2-real').textContent    = `${(+st.s2).toFixed(0)}°`;
+      qs('#s1-real').textContent    = `${(+st.x).toFixed(0)}°`;
+      qs('#s2-real').textContent    = `${(+st.a).toFixed(0)}°`;
       qs('#flow-real').textContent  = `${(+st.flow).toFixed(1)} ml/s`;
 
       // sync sliders with real readings only in automatic mode so user
       // adjustments remain visible during manual control
       if(!manualMode){
-        qs('#s1-slider')?.noUiSlider?.set(+st.s1);
-        qs('#s2-slider')?.noUiSlider?.set(+st.s2);
+        qs('#s1-slider')?.noUiSlider?.set(+st.x);
+        qs('#s2-slider')?.noUiSlider?.set(+st.a);
         qs('#servo-slider')?.noUiSlider?.set(+st.servo);
         qs('#flow-slider')?.noUiSlider?.set(+st.setpoint);
 
@@ -479,8 +480,8 @@ window.addEventListener('DOMContentLoaded', () => {
       }
        if(!manualMode){
         // keep chart targets aligned with current positions
-        s1Target = +st.s1;
-        s2Target = +st.s2;
+        s1Target = +st.x;
+        s2Target = +st.a;
        }
 
       autoExec=!!st.autoExecEnabled;
@@ -502,7 +503,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
       if(chartS1){
         dataS1.labels.push(tick);
-        dataS1.datasets[0].data.push(+st.s1);
+        dataS1.datasets[0].data.push(+st.x);
         dataS1.datasets[1].data.push(+s1Target);
         if(dataS1.labels.length>120){
           dataS1.labels.shift();
@@ -513,7 +514,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
       if(chartS2){
         dataS2.labels.push(tick);
-        dataS2.datasets[0].data.push(+st.s2);
+        dataS2.datasets[0].data.push(+st.a);
         dataS2.datasets[1].data.push(+s2Target);
         if(dataS2.labels.length>120){
           dataS2.labels.shift();


### PR DESCRIPTION
## Summary
- Track manual mode per actuator and expose it in `/status`
- Toggle individual manual modes from UI, sending the opposite of current state
- Apply motor energy without forcing manual mode
- Report Arduino `x` and `a` positions and display them in green badges

## Testing
- `python -m py_compile servidor_plantas.py && echo 'py_compile success'`


------
https://chatgpt.com/codex/tasks/task_e_689428bde8408330aca573c6f7c7f08c